### PR TITLE
Feat/retry lhw0507

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,9 @@ mod windowed_adder;
 
 pub mod backoff;
 pub mod failure_policy;
+pub mod retry_policy;
+mod retry_policy_builder;
+pub mod retry_policy_config;
 #[cfg(feature = "futures-support")]
 pub mod futures;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,6 @@
 //! ```
 
 #![deny(missing_debug_implementations)]
-#![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 
 mod circuit_breaker;

--- a/src/retry_policy.rs
+++ b/src/retry_policy.rs
@@ -1,0 +1,55 @@
+use crate::retry_policy_config::RetryPolicyConfig;
+use crate::retry_policy_builder::RetryPolicyBuilder;
+
+/// Represents a retry policy with configurable parameters for managing retry attempts.
+///
+/// This struct encapsulates various settings that control the behavior of retry operations,
+/// such as the maximum number of attempts, delays between retries, and backoff strategies.
+#[derive(Debug)]
+#[derive(Default)]
+pub struct RetryPolicy {
+    config: RetryPolicyConfig,
+}
+
+impl RetryPolicy {
+    pub fn builder() -> RetryPolicyBuilder {
+        RetryPolicyBuilder::new()
+    }
+
+    pub fn of_defaults() -> Self {
+        Self::builder().build()
+    }
+
+    pub fn get_config(&mut self) -> &mut RetryPolicyConfig {
+        &mut self.config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod build_test {
+        use core::time::Duration;
+        use crate::retry_policy::RetryPolicy;
+
+        #[test]
+        fn build_test() {
+            let mut policy = RetryPolicy::builder()
+                .with_simple_backoff(
+                    Duration::from_secs(1),
+                    Duration::from_secs(10),
+                ).expect("Failed to set simple backoff")
+                .with_jitter(0.5).expect("Failed to set jitter")
+                .with_max_attempts(5).expect("Failed to set max attempts")
+                .with_max_duration(Duration::from_secs(30)).expect("Failed to set max duration")
+                .with_max_retries(3).expect("Failed to set max retries")
+                .build();
+
+            let config = policy.get_config();
+            assert_eq!(config.max_delay(), Some(Duration::from_secs(10)));
+            assert_eq!(config.delay_factor(), 2.0);  // simple_backoff의 기본값
+            assert_eq!(config.jitter_factor(), 0.5);
+            assert_eq!(config.max_retries(), 3);
+            assert_eq!(config.max_duration(), Some(Duration::from_secs(30)));
+        }
+    }
+}

--- a/src/retry_policy_builder.rs
+++ b/src/retry_policy_builder.rs
@@ -1,0 +1,231 @@
+use std::time::Duration;
+use crate::retry_policy::RetryPolicy;
+
+pub type PolicyResult<T> = Result<T, &'static str>;
+
+#[derive(Debug)]
+pub struct RetryPolicyBuilder {
+    policy: RetryPolicy,
+}
+
+impl RetryPolicyBuilder {
+    pub fn new() -> Self {
+        RetryPolicyBuilder {
+            policy: RetryPolicy::default(),
+        }
+    }
+
+    pub fn with_simple_backoff(
+        self,
+        delay: Duration,
+        max_delay: Duration,
+    ) -> PolicyResult<Self> {
+        self.with_backoff(delay, max_delay, 2.0)
+    }
+
+    pub fn with_backoff(
+        mut self,
+        delay: Duration,
+        max_delay: Duration,
+        delay_factor: f64,
+    ) -> PolicyResult<Self> {
+        // Validate delay is positive and non-zero
+        if delay.is_zero() {
+            return Err("The delay must be greater than zero");
+        }
+
+        // Check if delay is less than max_duration if set
+        if let Some(max_duration) = self.policy.get_config().max_duration() {
+            if delay >= max_duration {
+                return Err("Delay must be less than the max duration");
+            }
+        }
+
+        // Check if delay is greater than or equal to jitter if set
+        if let Some(jitter) = self.policy.get_config().jitter() {
+            if delay < jitter {
+                return Err("Delay must be greater than or equal to the jitter duration");
+            }
+        }
+
+        // Check if delay is less than max_delay
+        if delay >= max_delay {
+            return Err("Delay must be less than the max delay");
+        }
+
+        // Check delay_factor
+        if delay_factor <= 1.0 {
+            return Err("Delay factor must be greater than 1");
+        }
+
+        // Set the values
+        self.policy.get_config()
+            .with_max_delay(Some(max_delay))
+            .with_delay_factor(delay_factor)
+            .with_delay_min(None)
+            .with_delay_max(None);
+
+        Ok(self)
+    }
+
+    pub fn with_delay(mut self, delay: Duration) -> PolicyResult<Self> {
+        // Ensure delay is not None
+        if delay.is_zero() {
+            return Err("Delay must not be None");
+        }
+
+        // Convert delay to a safe duration (assuming this means ensuring it's non-negative)
+        let delay = Duration::from_nanos(delay.as_nanos() as u64);
+
+        // Ensure delay is less than max_duration if set
+        if let Some(max_duration) = self.policy.get_config().max_duration() {
+            if delay >= max_duration {
+                return Err("Delay must be less than the max duration");
+            }
+        }
+
+        // Ensure delay is greater than or equal to jitter if set
+        if let Some(jitter) = self.policy.get_config().jitter() {
+            if delay < jitter {
+                return Err("Delay must be greater than or equal to the jitter duration");
+            }
+        }
+
+        // Clear backoff and random delays
+        self.policy.get_config()
+            .with_max_delay(None)
+            .with_delay_min(None)
+            .with_delay_max(None);
+
+        Ok(self)
+    }
+
+    pub fn with_delay_min_max(mut self, delay_min: Duration, delay_max: Duration) -> PolicyResult<Self> {
+        // Ensure delay_min and delay_max are not None
+        if delay_min.is_zero() || delay_max.is_zero() {
+            return Err("delayMin and delayMax must not be None");
+        }
+
+        // Convert delay_min and delay_max to safe durations
+        let delay_min = Duration::from_nanos(delay_min.as_nanos() as u64);
+        let delay_max = Duration::from_nanos(delay_max.as_nanos() as u64);
+
+        // Ensure delay_min is greater than 0
+        if delay_min.is_zero() || delay_min < Duration::ZERO {
+            return Err("delayMin must be greater than 0");
+        }
+
+        // Ensure delay_max is greater than 0
+        if delay_max.is_zero() || delay_max < Duration::ZERO {
+            return Err("delayMax must be greater than 0");
+        }
+
+        // Ensure delay_min is less than delay_max
+        if delay_min >= delay_max {
+            return Err("delayMin must be less than delayMax");
+        }
+
+        // Ensure delay_max is less than max_duration if set
+        if let Some(max_duration) = self.policy.get_config().max_duration() {
+            if delay_max >= max_duration {
+                return Err("delayMax must be less than the max duration");
+            }
+        }
+
+        // Ensure delay_min is greater than or equal to jitter if set
+        if let Some(jitter) = self.policy.get_config().jitter() {
+            if delay_min < jitter {
+                return Err("delayMin must be greater than or equal to the jitter duration");
+            }
+        }
+
+        // Set delay_min and delay_max in the configuration
+        self.policy.get_config()
+            .with_delay_min(Some(delay_min))
+            .with_delay_max(Some(delay_max));
+
+        // Clear fixed and random delays
+        self.policy.get_config()
+            //.with_delay(Some(Duration::ZERO))
+            .with_max_delay(None);
+
+        Ok(self)
+    }
+
+    pub fn with_jitter(mut self, jitter_factor: f64) -> PolicyResult<Self> {
+        // Ensure jitter_factor is between 0.0 and 1.0 inclusive
+        if jitter_factor < 0.0 || jitter_factor > 1.0 {
+            return Err("jitterFactor must be >= 0 and <= 1");
+        }
+
+        // Set jitter_factor in the configuration
+        self.policy.get_config().with_jitter_factor(jitter_factor);
+
+        // Clear the jitter duration
+        self.policy.get_config().with_jitter(None);
+
+        Ok(self)
+    }
+
+    pub fn with_max_attempts(mut self, max_attempts: i32) -> PolicyResult<Self> {
+        // Ensure max_attempts is not 0
+        if max_attempts == 0 {
+            return Err("maxAttempts cannot be 0");
+        }
+
+        // Ensure max_attempts is greater than or equal to -1
+        if max_attempts < -1 {
+            return Err("maxAttempts must be >= -1");
+        }
+
+        // Set max_retries in the configuration
+        self.policy.get_config().with_max_retries(if max_attempts == -1 { -1 } else { max_attempts - 1 });
+
+        Ok(self)
+    }
+
+    pub fn with_max_duration(mut self, max_duration: Duration) -> PolicyResult<Self> {
+        // Ensure max_duration is not None
+        if max_duration.is_zero() {
+            return Err("maxDuration must not be None");
+        }
+
+        // Convert max_duration to a safe duration
+        let max_duration = Duration::from_nanos(max_duration.as_nanos() as u64);
+
+        // Ensure max_duration is greater than the current delay
+        if let Some(delay) = self.policy.get_config().delay_min() {
+            if max_duration <= delay {
+                return Err("maxDuration must be greater than the delay");
+            }
+        }
+
+        // Ensure max_duration is greater than delay_max if set
+        if let Some(delay_max) = self.policy.get_config().delay_max() {
+            if max_duration <= delay_max {
+                return Err("maxDuration must be greater than the max random delay");
+            }
+        }
+
+        // Set max_duration in the configuration
+        self.policy.get_config().with_max_duration(Some(max_duration));
+
+        Ok(self)
+    }
+
+    pub fn with_max_retries(mut self, max_retries: i32) -> PolicyResult<Self> {
+        // Ensure max_retries is greater than or equal to -1
+        if max_retries < -1 {
+            return Err("maxRetries must be >= -1");
+        }
+
+        // Set max_retries in the configuration
+        self.policy.get_config().with_max_retries(max_retries);
+
+        Ok(self)
+    }
+
+    pub fn build(self) -> RetryPolicy {
+        self.policy
+    }
+}

--- a/src/retry_policy_config.rs
+++ b/src/retry_policy_config.rs
@@ -1,0 +1,145 @@
+use std::time::Duration;
+
+/// Configuration for RetryPolicy that specifies retry behavior settings.
+#[derive(Debug)]
+pub struct RetryPolicyConfig {
+    delay_min: Option<Duration>,
+    delay_max: Option<Duration>,
+    delay_factor: f64,
+    max_delay: Option<Duration>,
+    jitter: Option<Duration>,
+    jitter_factor: f64,
+    max_duration: Option<Duration>,
+    max_retries: i32,
+}
+
+impl Default for RetryPolicyConfig {
+    fn default() -> Self {
+        Self {
+            delay_min: None,
+            delay_max: None,
+            delay_factor: 1.0,
+            max_delay: None,
+            jitter: None,
+            jitter_factor: 0.0,
+            max_duration: None,
+            max_retries: 0,
+        }
+    }
+}
+
+impl RetryPolicyConfig {
+    /// Creates a new RetryPolicyConfig with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the minimum delay between retries
+    pub fn with_delay_min(&mut self, delay: Option<Duration>) -> &mut Self {
+        self.delay_min = delay;
+        self
+    }
+
+    /// Sets the maximum delay between retries
+    pub fn with_delay_max(&mut self, delay: Option<Duration>) -> &mut Self {
+        self.delay_max = delay;
+        self
+    }
+
+    /// Sets the delay factor
+    pub fn with_delay_factor(&mut self, factor: f64) -> &mut Self {
+        self.delay_factor = factor;
+        self
+    }
+
+    /// Sets the maximum delay
+    pub fn with_max_delay(&mut self, delay: Option<Duration>) -> &mut Self {
+        self.max_delay = delay;
+        self
+    }
+
+    /// Sets the jitter duration
+    pub fn with_jitter(&mut self, jitter: Option<Duration>) -> &mut Self {
+        self.jitter = jitter;
+        self
+    }
+
+    /// Sets the jitter factor
+    pub fn with_jitter_factor(&mut self, factor: f64) -> &mut Self {
+        self.jitter_factor = factor;
+        self
+    }
+
+    /// Sets the maximum duration for retries
+    pub fn with_max_duration(&mut self, duration: Option<Duration>) -> &mut Self {
+        self.max_duration = duration;
+        self
+    }
+
+    /// Sets the maximum number of retries
+    pub fn with_max_retries(&mut self, retries: i32) -> &mut Self {
+        self.max_retries = retries;
+        self
+    }
+
+    // Getter methods
+    pub fn delay_min(&self) -> Option<Duration> {
+        self.delay_min
+    }
+
+    pub fn delay_max(&self) -> Option<Duration> {
+        self.delay_max
+    }
+
+    pub fn delay_factor(&self) -> f64 {
+        self.delay_factor
+    }
+
+    pub fn max_delay(&self) -> Option<Duration> {
+        self.max_delay
+    }
+
+    pub fn jitter(&self) -> Option<Duration> {
+        self.jitter
+    }
+
+    pub fn jitter_factor(&self) -> f64 {
+        self.jitter_factor
+    }
+
+    pub fn max_duration(&self) -> Option<Duration> {
+        self.max_duration
+    }
+
+    pub fn max_retries(&self) -> i32 {
+        self.max_retries
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_retry_policy_config() {
+        let mut config: RetryPolicyConfig = RetryPolicyConfig::new();
+        config
+            .with_delay_min(Some(Duration::from_secs(1)))
+            .with_delay_max(Some(Duration::from_secs(5)))
+            .with_delay_factor(2.0)
+            .with_max_delay(Some(Duration::from_secs(10)))
+            .with_jitter(Some(Duration::from_millis(100)))
+            .with_jitter_factor(0.5)
+            .with_max_duration(Some(Duration::from_secs(30)))
+            .with_max_retries(3);
+
+        assert_eq!(config.delay_min(), Some(Duration::from_secs(1)));
+        assert_eq!(config.delay_max(), Some(Duration::from_secs(5)));
+        assert_eq!(config.delay_factor(), 2.0);
+        assert_eq!(config.max_delay(), Some(Duration::from_secs(10)));
+        assert_eq!(config.jitter(), Some(Duration::from_millis(100)));
+        assert_eq!(config.jitter_factor(), 0.5);
+        assert_eq!(config.max_duration(), Some(Duration::from_secs(30)));
+        assert_eq!(config.max_retries(), 3);
+    }
+}


### PR DESCRIPTION
인터페이스와 retry config의 abortConditions을 제외하고 빌더를 이용한 RetryPolicy 생성 구현